### PR TITLE
[FPOS-43105] Update to Spring Boot 4.1

### DIFF
--- a/.github/workflows/cd_build.yml
+++ b/.github/workflows/cd_build.yml
@@ -12,10 +12,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
           server-id: github # Value of the distributionManagement/repository/id field of the pom.xml
           settings-path: ${{ github.workspace }} # location for the settings.xml file
 

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -11,7 +11,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest]
-        jdk: [17]
+        jdk: [21]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/pull_request_delombok.yml
+++ b/.github/workflows/pull_request_delombok.yml
@@ -13,10 +13,10 @@ jobs:
 
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
 
       - name: Build with Maven and delombok
         run: mvn -Pdelombok -B package

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Set up JDK 17
+      - name: Set up JDK 21
         uses: actions/setup-java@v1
         with:
-          java-version: 17
+          java-version: 21
           settings-path: ~ # location for the settings.xml file
 
       - name: Build and publish

--- a/pom.xml
+++ b/pom.xml
@@ -22,8 +22,8 @@
 
   <properties>
     <!-- Core -->
-    <maven.compiler.source>17</maven.compiler.source>
-    <maven.compiler.target>17</maven.compiler.target>
+    <maven.compiler.source>21</maven.compiler.source>
+    <maven.compiler.target>21</maven.compiler.target>
     <file.encoding>UTF-8</file.encoding>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -34,9 +34,9 @@
     <skip.format>false</skip.format>
 
     <!-- Dependency versions -->
-    <logback.version>1.2.11</logback.version>
+    <logback.version>1.5.34</logback.version>
     <revision>1.3.99999-SNAPSHOT</revision>
-    <junit.jupiter.version>5.9.1</junit.jupiter.version>
+    <junit.jupiter.version>6.0.3</junit.jupiter.version>
     <testcontainers.version>1.17.6</testcontainers.version>
   </properties>
 
@@ -54,12 +54,12 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.36</version>
+        <version>2.0.18</version>
       </dependency>
       <dependency>
         <groupId>net.bytebuddy</groupId>
         <artifactId>byte-buddy</artifactId>
-        <version>1.12.20</version>
+        <version>1.18.10</version>
         <optional>true</optional>
       </dependency>
       <dependency>

--- a/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestingUtils.java
+++ b/transactionoutbox-core/src/test/java/com/gruelbox/transactionoutbox/TestingUtils.java
@@ -12,7 +12,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DynamicContainer;
 import org.junit.jupiter.api.DynamicNode;
 import org.junit.jupiter.api.DynamicTest;
-import org.junit.jupiter.engine.discovery.predicates.IsTestMethod;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.platform.commons.util.AnnotationUtils;
 import org.junit.platform.commons.util.ReflectionUtils;
@@ -30,7 +30,8 @@ public class TestingUtils {
   public static Stream<DynamicNode> parameterizedClassTester(
       String displayName, Class<?> clazz, Stream<Arguments> streamOfArguments) {
 
-    final List<Method> testMethods = ReflectionUtils.findMethods(clazz, new IsTestMethod());
+    final List<Method> testMethods =
+        ReflectionUtils.findMethods(clazz, method -> AnnotationUtils.isAnnotated(method, Test.class));
     if (testMethods.isEmpty()) {
       throw new IllegalStateException(clazz.getName() + " has no supported @Test methods");
     }

--- a/transactionoutbox-spring/pom.xml
+++ b/transactionoutbox-spring/pom.xml
@@ -16,8 +16,8 @@
   </description>
 
   <properties>
-    <spring.boot.version>3.4.2</spring.boot.version>
-    <spring.version>6.2.2</spring.version>
+    <spring.boot.version>4.1.0</spring.boot.version>
+    <spring.version>7.0.8</spring.version>
   </properties>
 
   <dependencies>
@@ -41,9 +41,10 @@
       <scope>provided</scope>
     </dependency>
     <dependency>
-      <groupId>javax.inject</groupId>
-      <artifactId>javax.inject</artifactId>
-      <version>1</version>
+      <groupId>jakarta.inject</groupId>
+      <artifactId>jakarta.inject-api</artifactId>
+      <version>2.0.1</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.springframework</groupId>
@@ -90,6 +91,18 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-resttestclient</artifactId>
+      <version>${spring.boot.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-restclient</artifactId>
       <version>${spring.boot.version}</version>
       <scope>test</scope>
     </dependency>

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentController.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentController.java
@@ -2,7 +2,7 @@ package com.gruelbox.transactionoutbox.acceptance;
 
 import com.gruelbox.transactionoutbox.TransactionOutbox;
 import java.time.LocalDateTime;
-import javax.inject.Provider;
+import jakarta.inject.Provider;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentControllerTest.java
+++ b/transactionoutbox-spring/src/test/java/com/gruelbox/transactionoutbox/acceptance/EventuallyConsistentControllerTest.java
@@ -4,15 +4,17 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 
 import java.net.URL;
-import javax.inject.Inject;
+import jakarta.inject.Inject;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.boot.resttestclient.TestRestTemplate;
+import org.springframework.boot.resttestclient.autoconfigure.AutoConfigureTestRestTemplate;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
 import org.springframework.boot.test.web.server.LocalServerPort;
 import org.springframework.http.ResponseEntity;
 
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@AutoConfigureTestRestTemplate
 class EventuallyConsistentControllerTest {
 
   @LocalServerPort private int port;


### PR DESCRIPTION
## Summary

Updates the `transactionoutbox-spring` module from Spring Boot 3.4.2 to **Spring Boot 4.1.0** (Spring Framework 7), including the dependency, API and CI changes required by the new baseline.

## Changes

**Root `pom.xml`**
- Java 17 → **21** (Spring Boot 4 baseline)
- ByteBuddy 1.12.20 → **1.18.10** (1.12.x cannot define classes on Java 21)
- JUnit Jupiter 5.9.1 → **6.0.3** (Spring Framework 7 requires JUnit 6; old version caused `NoSuchMethodError` in `SpringExtension`)
- Logback 1.2.11 → **1.5.34** and SLF4J 1.7.36 → **2.0.18** (Spring Boot 4.1 references `StatusPrinter2`, only present in Logback 1.3+)

**`transactionoutbox-spring/pom.xml`**
- `spring.boot.version` 3.4.2 → **4.1.0**, `spring.version` 6.2.2 → **7.0.8**
- `javax.inject:javax.inject` → **`jakarta.inject:jakarta.inject-api`** (test scope)
- Added test deps **`spring-boot-resttestclient`** and **`spring-boot-restclient`** (these moved into their own modules in Boot 4)

**`transactionoutbox-spring` test sources**
- `javax.inject` → `jakarta.inject` (Spring 6/7 uses the Jakarta namespace)
- `TestRestTemplate` import moved to `org.springframework.boot.resttestclient`
- Added `@AutoConfigureTestRestTemplate` (auto-registration at `RANDOM_PORT` was removed in Boot 4)

**`transactionoutbox-core` test sources**
- `TestingUtils` used the internal JUnit engine class `IsTestMethod`, whose constructor now requires a `DiscoveryIssueReporter` in JUnit 6 — this broke the (clean) test compilation that JitPack and CI perform even with `-DskipTests`. Replaced the internal predicate with a stable `@Test`-annotation check via the public commons API.

**CI (`.github/workflows/`)**
- Bumped the JDK in all four workflows (`cd_build`, `pull_request`, `pull_request_delombok`, `release`) from **17 → 21**, mirroring the JDK 11 → 17 bump done in the 3.4.2 update (PR #3).

## Verification

- `mvn -pl transactionoutbox-spring test` compiles and passes.
- `mvn clean install -DskipTests` builds the whole reactor (all 7 modules) — mirrors how JitPack/CI build.
- Verified end-to-end via JitPack: the branch builds successfully with JDK 21 (`clean install -DskipTests`, `BUILD SUCCESS`) and publishes all artifacts, so downstream projects can consume it.
- The `core` module's non-Docker tests remain green; the Docker-based tests (Testcontainers) are environmental and unaffected.

## Known issue (pre-existing, not introduced here)

`EventuallyConsistentControllerTest` is intermittently flaky (~25%). Root cause: the immediate post-commit processing calls `orderedLock(...)` with `FOR UPDATE SKIP LOCKED`; when it loses the race it logs `Skipped task`, and because a new entry's `nextAttemptTime` is `now + attemptFrequency` (default **2 min**), the background flush query (`nextAttemptTime < now`) cannot pick it up within the test's 10 s window. This behaviour predates this change (introduced by the ordered-processing work; the demo app is identical on the base branch) and is independent of the Spring Boot upgrade. Note JitPack/CI build with `-DskipTests`, so this does not affect distribution.
